### PR TITLE
Fix importing of sub-crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,10 @@ name = "fsm"
 version = "0.1.0"
 authors = ["Rudi Benkovic <rudi.benkovic@gmail.com>"]
 
-[dependencies]
-
 [features]
 default = ["std"]
 std = []
 core_collections = []
+
+[workspace]
+members = ["fsm_codegen", "fsm_tests"]


### PR DESCRIPTION
This PR allows users to depend on sub-crates (e.g.,`fsm_codegen`) from the root of the git repository.