### PR TITLE
Allow specifying the Context type in state factories

### DIFF
--- a/fsm_tests/tests/boost_composite.rs
+++ b/fsm_tests/tests/boost_composite.rs
@@ -90,11 +90,11 @@ impl FsmState<Player> for Playing {
 
 	fn on_exit(&mut self, event_context: &mut EventContext<Player>) {
         event_context.context.playing_fsm_exit_counter += 1;
-    }    
+    }
 }
 
-impl FsmStateFactory for Playing {
-    fn new_state<PlayerContext>(parent_context: &PlayerContext) -> Self {
+impl FsmStateFactory<PlayerContext> for Playing {
+    fn new_state(parent_context: &PlayerContext) -> Self {
         Playing::new(Default::default())
     }
 }
@@ -103,7 +103,7 @@ impl FsmStateFactory for Playing {
 
 pub struct StartPlayback;
 impl FsmAction<Player, Stopped, Playing> for StartPlayback {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Stopped, target_state: &mut Playing) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Stopped, target_state: &mut Playing) {
         println!("StartPlayback");
         event_context.context.start_playback_counter += 1;
 	}
@@ -111,38 +111,38 @@ impl FsmAction<Player, Stopped, Playing> for StartPlayback {
 
 pub struct OpenDrawer;
 impl FsmAction<Player, Empty, Open> for OpenDrawer {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Empty, target_state: &mut Open) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Empty, target_state: &mut Open) {
         println!("OpenDrawer");
 	}
 }
 impl FsmAction<Player, Stopped, Open> for OpenDrawer {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Stopped, target_state: &mut Open) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Stopped, target_state: &mut Open) {
         println!("OpenDrawer");
 	}
 }
 
 pub struct CloseDrawer;
 impl FsmAction<Player, Open, Empty> for CloseDrawer {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Open, target_state: &mut Empty) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Open, target_state: &mut Empty) {
         println!("CloseDrawer");
 	}
 }
 
 pub struct StoreCdInfo;
 impl FsmAction<Player, Empty, Stopped> for StoreCdInfo {
-    fn action(event_context: &mut EventContext<Player>, source_state: &mut Empty, target_state: &mut Stopped) {		
+    fn action(event_context: &mut EventContext<Player>, source_state: &mut Empty, target_state: &mut Stopped) {
         match event_context.event {
             &PlayerEvents::CdDetected(CdDetected { name: ref name }) => {
                 println!("StoreCdInfo: name = {}", name);
             },
             _ => { panic!("Mismatched event!"); }
-        }        
+        }
 	}
 }
 
 pub struct StopPlayback;
 impl FsmAction<Player, Playing, Stopped> for StopPlayback {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Stopped) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Stopped) {
         println!("StopPlayback");
 	}
 }
@@ -154,7 +154,7 @@ impl FsmAction<Player, Paused, Stopped> for StopPlayback {
 
 pub struct PausePlayback;
 impl FsmAction<Player, Playing, Paused> for PausePlayback {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Paused) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Paused) {
         println!("PausePlayback");
 	}
 }
@@ -168,12 +168,12 @@ impl FsmAction<Player, Paused, Playing> for ResumePlayback {
 
 pub struct StopAndOpen;
 impl FsmAction<Player, Playing, Open> for StopAndOpen {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Open) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Open) {
         println!("StopAndOpen");
 	}
 }
 impl FsmAction<Player, Paused, Open> for StopAndOpen {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Paused, target_state: &mut Open) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Paused, target_state: &mut Open) {
         println!("StopAndOpen");
 	}
 }
@@ -213,7 +213,7 @@ struct PlayerDefinition(
 	ContextType<PlayerContext>,
 
     SubMachine<Playing>,
-    
+
     Transition<Player, Stopped,     Play,       Playing,    StartPlayback>,
     Transition<Player, Stopped,     OpenClose,  Open,       OpenDrawer>,
     TransitionSelf<Player, Stopped,     Stop,               StoppedAgain>,
@@ -288,7 +288,7 @@ impl FsmState<Playing> for Song3 {
 // Actions
 pub struct StartNextSong;
 impl FsmAction<Playing, Song1, Song2> for StartNextSong {
-	fn action(event_context: &mut EventContext<Playing>, source_state: &mut Song1, target_state: &mut Song2) {		
+	fn action(event_context: &mut EventContext<Playing>, source_state: &mut Song1, target_state: &mut Song2) {
         println!("Playing::StartNextSong");
 	}
 }
@@ -300,7 +300,7 @@ impl FsmAction<Playing, Song2, Song3> for StartNextSong {
 
 pub struct StartPrevSong;
 impl FsmAction<Playing, Song2, Song1> for StartPrevSong {
-	fn action(event_context: &mut EventContext<Playing>, source_state: &mut Song2, target_state: &mut Song1) {		
+	fn action(event_context: &mut EventContext<Playing>, source_state: &mut Song2, target_state: &mut Song1) {
         println!("Playing::StartPrevSong");
 	}
 }
@@ -324,7 +324,7 @@ pub struct PlayingContext {
 struct PlayingDefinition(
 	InitialState<Playing, Song1>,
     ContextType<PlayingContext>,
-        
+
     Transition<Playing, Song1,  NextSong,       Song2,  StartNextSong>,
     Transition<Playing, Song2,  PreviousSong,   Song1,  StartPrevSong>,
 
@@ -346,7 +346,7 @@ fn test_player() {
     assert_eq!(1, p.get_context().action_empty_exit_counter);
     assert_eq!(1, p.get_context().action_open_entry_counter);
 
-    
+
     p.process_event(PlayerEvents::OpenClose(OpenClose)).unwrap();
     assert_eq!(PlayerStates::Empty, p.get_current_state());
     assert_eq!(2, p.get_context().action_empty_entry_counter);
@@ -354,10 +354,10 @@ fn test_player() {
 
     p.process_event(PlayerEvents::CdDetected(CdDetected { name: "louie, louie".to_string() })).unwrap();
     assert_eq!(PlayerStates::Stopped, p.get_current_state());
-    assert_eq!(1, p.get_context().action_stopped_entry_counter);    
+    assert_eq!(1, p.get_context().action_stopped_entry_counter);
     assert_eq!(2, p.get_context().action_empty_exit_counter);
-    
-    
+
+
     p.process_event(PlayerEvents::Play(Play)).unwrap();
     assert_eq!(PlayerStates::Playing, p.get_current_state());
 
@@ -368,10 +368,10 @@ fn test_player() {
     assert_eq!(1, p.get_context().playing_fsm_entry_counter);
     assert_eq!(1, p.get_context().start_playback_counter);
 
-    
+
     {
         let sub: &mut Playing = p.get_state_mut();
-        sub.process_event(PlayingEvents::NextSong(NextSong)).unwrap();    
+        sub.process_event(PlayingEvents::NextSong(NextSong)).unwrap();
         assert_eq!(PlayingStates::Song2, sub.get_current_state());
         assert_eq!(1, sub.get_context().song1_exit_counter);
         assert_eq!(1, sub.get_context().song2_entry_counter);
@@ -416,7 +416,7 @@ fn test_player() {
     assert_eq!(2, p.get_context().action_stopped_exit_counter);
     assert_eq!(3, p.get_context().action_stopped_entry_counter);
 
-    
+
     p.process_event(PlayerEvents::Play(Play)).unwrap();
     assert_eq!(PlayerStates::Playing, p.get_current_state());
     {
@@ -424,5 +424,5 @@ fn test_player() {
         assert_eq!(PlayingStates::Song1, sub.get_current_state());
         assert_eq!(3, sub.get_context().song1_entry_counter);
     }
-    
+
 }

--- a/fsm_tests/tests/boost_history.rs
+++ b/fsm_tests/tests/boost_history.rs
@@ -90,11 +90,11 @@ impl FsmState<Player> for Playing {
 
 	fn on_exit(&mut self, event_context: &mut EventContext<Player>) {
         event_context.context.playing_fsm_exit_counter += 1;
-    }    
+    }
 }
 
-impl FsmStateFactory for Playing {
-    fn new_state<PlayerContext>(parent_context: &PlayerContext) -> Self {
+impl FsmStateFactory<PlayerContext> for Playing {
+    fn new_state(parent_context: &PlayerContext) -> Self {
         Playing::new(Default::default())
     }
 }
@@ -104,7 +104,7 @@ impl FsmStateFactory for Playing {
 
 pub struct StartPlayback;
 impl FsmAction<Player, Stopped, Playing> for StartPlayback {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Stopped, target_state: &mut Playing) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Stopped, target_state: &mut Playing) {
         println!("StartPlayback");
         event_context.context.start_playback_counter += 1;
 	}
@@ -112,38 +112,38 @@ impl FsmAction<Player, Stopped, Playing> for StartPlayback {
 
 pub struct OpenDrawer;
 impl FsmAction<Player, Empty, Open> for OpenDrawer {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Empty, target_state: &mut Open) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Empty, target_state: &mut Open) {
         println!("OpenDrawer");
 	}
 }
 impl FsmAction<Player, Stopped, Open> for OpenDrawer {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Stopped, target_state: &mut Open) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Stopped, target_state: &mut Open) {
         println!("OpenDrawer");
 	}
 }
 
 pub struct CloseDrawer;
 impl FsmAction<Player, Open, Empty> for CloseDrawer {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Open, target_state: &mut Empty) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Open, target_state: &mut Empty) {
         println!("CloseDrawer");
 	}
 }
 
 pub struct StoreCdInfo;
 impl FsmAction<Player, Empty, Stopped> for StoreCdInfo {
-    fn action(event_context: &mut EventContext<Player>, source_state: &mut Empty, target_state: &mut Stopped) {		
+    fn action(event_context: &mut EventContext<Player>, source_state: &mut Empty, target_state: &mut Stopped) {
         match event_context.event {
             &PlayerEvents::CdDetected(CdDetected { name: ref name }) => {
                 println!("StoreCdInfo: name = {}", name);
             },
             _ => { panic!("Mismatched event!"); }
-        }        
+        }
 	}
 }
 
 pub struct StopPlayback;
 impl FsmAction<Player, Playing, Stopped> for StopPlayback {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Stopped) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Stopped) {
         println!("StopPlayback");
 	}
 }
@@ -155,7 +155,7 @@ impl FsmAction<Player, Paused, Stopped> for StopPlayback {
 
 pub struct PausePlayback;
 impl FsmAction<Player, Playing, Paused> for PausePlayback {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Paused) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Paused) {
         println!("PausePlayback");
 	}
 }
@@ -169,12 +169,12 @@ impl FsmAction<Player, Paused, Playing> for ResumePlayback {
 
 pub struct StopAndOpen;
 impl FsmAction<Player, Playing, Open> for StopAndOpen {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Open) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Playing, target_state: &mut Open) {
         println!("StopAndOpen");
 	}
 }
 impl FsmAction<Player, Paused, Open> for StopAndOpen {
-	fn action(event_context: &mut EventContext<Player>, source_state: &mut Paused, target_state: &mut Open) {		
+	fn action(event_context: &mut EventContext<Player>, source_state: &mut Paused, target_state: &mut Open) {
         println!("StopAndOpen");
 	}
 }
@@ -215,7 +215,7 @@ struct PlayerDefinition(
 
     SubMachine<Playing>,
     ShallowHistory<Player, EndPause, Playing>,
-    
+
     Transition<Player, Stopped,     Play,       Playing,    StartPlayback>,
     Transition<Player, Stopped,     OpenClose,  Open,       OpenDrawer>,
     TransitionSelf<Player, Stopped,     Stop,               StoppedAgain>,
@@ -292,7 +292,7 @@ impl FsmState<Playing> for Song3 {
 // Actions
 pub struct StartNextSong;
 impl FsmAction<Playing, Song1, Song2> for StartNextSong {
-	fn action(event_context: &mut EventContext<Playing>, source_state: &mut Song1, target_state: &mut Song2) {		
+	fn action(event_context: &mut EventContext<Playing>, source_state: &mut Song1, target_state: &mut Song2) {
         println!("Playing::StartNextSong");
 	}
 }
@@ -304,7 +304,7 @@ impl FsmAction<Playing, Song2, Song3> for StartNextSong {
 
 pub struct StartPrevSong;
 impl FsmAction<Playing, Song2, Song1> for StartPrevSong {
-	fn action(event_context: &mut EventContext<Playing>, source_state: &mut Song2, target_state: &mut Song1) {		
+	fn action(event_context: &mut EventContext<Playing>, source_state: &mut Song2, target_state: &mut Song1) {
         println!("Playing::StartPrevSong");
 	}
 }
@@ -329,7 +329,7 @@ pub struct PlayingContext {
 struct PlayingDefinition(
 	InitialState<Playing, Song1>,
     ContextType<PlayingContext>,
-        
+
     Transition<Playing, Song1,  NextSong,       Song2,  StartNextSong>,
     Transition<Playing, Song2,  PreviousSong,   Song1,  StartPrevSong>,
 
@@ -352,7 +352,7 @@ fn test_player() {
     assert_eq!(1, p.get_context().action_empty_exit_counter);
     assert_eq!(1, p.get_context().action_open_entry_counter);
 
-    
+
     p.process_event(PlayerEvents::OpenClose(OpenClose)).unwrap();
     assert_eq!(PlayerStates::Empty, p.get_current_state());
     assert_eq!(2, p.get_context().action_empty_entry_counter);
@@ -360,10 +360,10 @@ fn test_player() {
 
     p.process_event(PlayerEvents::CdDetected(CdDetected { name: "louie, louie".to_string() })).unwrap();
     assert_eq!(PlayerStates::Stopped, p.get_current_state());
-    assert_eq!(1, p.get_context().action_stopped_entry_counter);    
+    assert_eq!(1, p.get_context().action_stopped_entry_counter);
     assert_eq!(2, p.get_context().action_empty_exit_counter);
-    
-    
+
+
     p.process_event(PlayerEvents::Play(Play)).unwrap();
     assert_eq!(PlayerStates::Playing, p.get_current_state());
 
@@ -374,10 +374,10 @@ fn test_player() {
     assert_eq!(1, p.get_context().playing_fsm_entry_counter);
     assert_eq!(1, p.get_context().start_playback_counter);
 
-    
+
     {
         let sub: &mut Playing = p.get_state_mut();
-        sub.process_event(PlayingEvents::NextSong(NextSong)).unwrap();    
+        sub.process_event(PlayingEvents::NextSong(NextSong)).unwrap();
         assert_eq!(PlayingStates::Song2, sub.get_current_state());
         assert_eq!(1, sub.get_context().song1_exit_counter);
         assert_eq!(1, sub.get_context().song2_entry_counter);
@@ -422,7 +422,7 @@ fn test_player() {
     assert_eq!(2, p.get_context().action_stopped_exit_counter);
     assert_eq!(3, p.get_context().action_stopped_entry_counter);
 
-    
+
     p.process_event(PlayerEvents::Play(Play)).unwrap();
     assert_eq!(PlayerStates::Playing, p.get_current_state());
     {
@@ -430,6 +430,6 @@ fn test_player() {
         assert_eq!(PlayingStates::Song1, sub.get_current_state());
         assert_eq!(2, sub.get_context().song1_entry_counter);
     }
-    
+
 }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -20,9 +20,9 @@ pub trait FsmEvents<F: Fsm> {
 	fn new_no_event() -> Self;
 }
 
-pub trait FsmState<F: Fsm> {	
+pub trait FsmState<F: Fsm> {
 	fn on_entry(&mut self, event_context: &mut EventContext<F>) { }
-	fn on_exit(&mut self, event_context: &mut EventContext<F>) { }		
+	fn on_exit(&mut self, event_context: &mut EventContext<F>) { }
 }
 
 pub trait FsmInspect<F: Fsm> {
@@ -87,17 +87,17 @@ impl<A, B> FsmStateFactory for (A, B) {
 /*
 pub trait FsmStateSubMachineTransition<F: Fsm> {
 	fn on_entry_internal(&mut self) { }
-	fn on_exit_internal(&mut self) { } 	
+	fn on_exit_internal(&mut self) { }
 }
 */
 
 
-pub trait FsmStateFactory {
-	fn new_state<C>(parent_context: &C) -> Self;
+pub trait FsmStateFactory<Context> {
+	fn new_state(parent_context: &Context) -> Self;
 }
 
-impl<S: Default> FsmStateFactory for S {
-	fn new_state<C>(parent_context: &C) -> Self {
+impl<S: Default, Context> FsmStateFactory<Context> for S {
+	fn new_state(parent_context: &Context) -> Self {
 		Default::default()
 	}
 }
@@ -208,7 +208,7 @@ pub trait Fsm where Self: Sized {
 	fn get_current_state(&self) -> Self::CS;
 	fn get_states(&self) -> &Self::SS;
 	fn get_states_mut(&mut self) -> &mut Self::SS;
-	
+
 	fn process_anonymous_transitions(&mut self) -> Result<(), FsmError> {
 		loop {
 			match self.process_event(Self::E::new_no_event()) {
@@ -220,11 +220,11 @@ pub trait Fsm where Self: Sized {
 		}
 
 		Ok(())
-	}	
+	}
 
 	fn process_event(&mut self, event: Self::E) -> Result<(), FsmError>;
 
-	
+
 	fn execute_queued_events(&mut self) -> FsmQueueStatus {
 		if self.get_queue().len() == 0 { return FsmQueueStatus::Empty; }
 
@@ -243,7 +243,7 @@ pub trait Fsm where Self: Sized {
 
 		if self.get_queue().len() == 0 { FsmQueueStatus::Empty } else { FsmQueueStatus::MoreEventsQueued }
 	}
-	
+
 	fn get_message_queue_size(&self) -> usize {
 		self.get_queue().len()
 	}


### PR DESCRIPTION
This PR converts the `Context` generic type from a function type to a struct type in state factories. The change is made because the type needs to be known in the implementation of the factory, not when calling it.